### PR TITLE
Fix wrong parameter defaults for wallets/{walletId}/accounts'(get)

### DIFF
--- a/ncw-open-api.yaml
+++ b/ncw-open-api.yaml
@@ -193,10 +193,10 @@ paths:
           required: false
           in: query
           schema:
-            default:
-              enum:
-                - id
             type: string
+            enum:
+              - id
+            default: id
         - name: order
           required: false
           in: query


### PR DESCRIPTION
Running

> openapi-generator-cli generate --package-name io.fireblocks.client --input-spec ncw-open-api.yaml --generator-name kotlin --output gen

reported this error:

Exception in thread "main" org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 1, Warning count: 0
Errors:
	-attribute paths.'/v1/ncw/wallets/{walletId}/accounts'(get).parameters.[sort].schemas.default is not of type `string`

	at org.openapitools.codegen.config.CodegenConfigurator.toContext(CodegenConfigurator.java:668)
	at org.openapitools.codegen.config.CodegenConfigurator.toClientOptInput(CodegenConfigurator.java:695)
	at org.openapitools.codegen.cmd.Generate.execute(Generate.java:503)
	at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
	at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)